### PR TITLE
docs: explain network hook rationale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,29 @@
 # europa1400-networkfix
 
 A network stability patch for *Europa 1400: The Guild* implemented as an `.asi` plugin.
-The project builds a Windows dynamic library using [Zig](https://ziglang.org/) and
-[MinHook](https://github.com/TsudaKageyu/minhook) to intercept network calls.
+
+## Why?
+
+The game's original multiplayer mode depends on `server.dll` for all network
+communication.  That implementation assumes perfect packet delivery and will
+desynchronize or disconnect clients on even minor packet loss.  Playing over
+VPNs such as Hamachi or Radmin is therefore nearly impossible because the game
+quickly throws "out of sync" errors.
+
+This project draws on research from [The-Guild-1-HookDLLs](https://github.com/maci0/The-Guild-1-HookDLLs)
+and provides a lightweight fix aimed at making the network stack resilient to
+real‑world connections.
+
+## How?
+
+The `.asi` plugin is injected into the game and uses
+[MinHook](https://github.com/TsudaKageyu/minhook) to intercept functions inside
+`server.dll` and the Windows networking APIs.  By patching these routines we add
+basic error handling and retry logic, allowing multiplayer sessions to survive
+packet loss and latency.
+
+The project builds a Windows dynamic library using [Zig](https://ziglang.org/)
+and MinHook to implement the hooks.
 
 ## Project structure
 


### PR DESCRIPTION
## Summary
- clarify why networking fails in the base game
- describe how the `.asi` plugin intercepts `server.dll` and Windows APIs to stabilize multiplayer

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68bd2f2b09408327988e6ab8d30cfcbf