### PR TITLE
Define logging globals in source file

### DIFF
--- a/src/logging.c
+++ b/src/logging.c
@@ -10,6 +10,11 @@
 
 #include "logging.h"
 
+CRITICAL_SECTION g_LogCriticalSection;
+bool g_CriticalSectionInitialized = false;
+HANDLE g_LogFile = INVALID_HANDLE_VALUE;
+UINT32 g_LogLineCount = 0;
+
 static const DWORD kMaxLogLines = 500;  // Max lines before rollover
 
 static void ResetLogFile(void) {

--- a/src/logging.h
+++ b/src/logging.h
@@ -6,10 +6,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-static CRITICAL_SECTION g_LogCriticalSection;
-static bool g_CriticalSectionInitialized = false;
-static HANDLE g_LogFile = INVALID_HANDLE_VALUE;
-static UINT32 g_LogLineCount = 0;
+extern CRITICAL_SECTION g_LogCriticalSection;
+extern bool g_CriticalSectionInitialized;
+extern HANDLE g_LogFile;
+extern UINT32 g_LogLineCount;
 
 void init_logging(HMODULE hModule);
 void close_logging(void);


### PR DESCRIPTION
## Summary
- Declare logging globals as extern in `logging.h`
- Define logging globals in `logging.c` to ensure single shared instance

## Testing
- `make`
- `grep -i warning /tmp/make.log`


------
https://chatgpt.com/codex/tasks/task_e_68bd3dbec624832789a37052743e954f